### PR TITLE
Improvements to LaTex generator (pdf)

### DIFF
--- a/render_pdf.sh
+++ b/render_pdf.sh
@@ -32,3 +32,4 @@ cat ${__dir}/src/formats/${format}_${papersize}_s.tex >> ${tex_file}
 # Run pdflatex twice to recalculate longtables
 TEXINPUTS=.:${__dir}/src/latex: pdflatex -output-directory ${tex_dir} ${tex_file}
 TEXINPUTS=.:${__dir}/src/latex: pdflatex -output-directory ${tex_dir} ${tex_file}
+TEXINPUTS=.:${__dir}/src/latex: pdflatex -output-directory ${tex_dir} ${tex_file}

--- a/src/formats/songbook_a4_s.tex
+++ b/src/formats/songbook_a4_s.tex
@@ -1,5 +1,5 @@
 \newpage
-\fancyhead[LE]{SPIS TREśCI}
-\fancyhead[RO]{SPIS TREśCI}
+\fancyhead[LE]{SPIS TREŚCI}
+\fancyhead[RO]{SPIS TREŚCI}
 \tableofcontents
 \end{document}

--- a/src/formats/songbook_a5_s.tex
+++ b/src/formats/songbook_a5_s.tex
@@ -1,5 +1,5 @@
 \newpage
-\fancyhead[LE]{SPIS TREśCI}
-\fancyhead[RO]{SPIS TREśCI}
+\fancyhead[LE]{SPIS TREŚCI}
+\fancyhead[RO]{SPIS TREŚCI}
 \tableofcontents
 \end{document}

--- a/src/latex/songbook21wdh.sty
+++ b/src/latex/songbook21wdh.sty
@@ -4,6 +4,10 @@
 
 \RequirePackage{conditionals}
 \RequirePackage{ifthen}
+\RequirePackage{xstring}
+\RequirePackage{booktabs}
+\RequirePackage{array}
+\RequirePackage{varwidth} % must be loaded after array
 
 \newcommand{\theSongTitle}{}
 \newcommand{\theSongLyricist}{}
@@ -18,11 +22,11 @@
 
 \newcommand{\ChBassFont}{\normalsize\bf\sf}     % = cmss12 at 12.0pt
 \newcommand{\SBChordRaise}       {2.25ex}
-\newcommand{\ChFontOn}{\scriptsize\fontfamily{\sfdefault}
+\newcommand{\ChFontOn}{\scriptsize\fontfamily{\sfdefault}%
   \fontseries{sbc}\fontshape{n}\selectfont}     %=cmssbc12 at 14.4pt
-\newcommand{\ChFontBh}{\fontfamily{\sfdefault}
+\newcommand{\ChFontBh}{\fontfamily{\sfdefault}%
   \fontseries{sbc}\fontshape{n}\selectfont}     %=cmssbc12 at 14.4pt
-\newcommand{\ChBkFont}{\ChFont\fontseries{m}
+\newcommand{\ChBkFont}{\ChFont\fontseries{m}%
   \selectfont}                                  % =cmssm12 at 14.4pt
 
 \newcommand{\bis}{\vrule}
@@ -67,21 +71,20 @@
     \setbox1=\hbox{\ChFontOn\sbChord{#1}\relax\strut}%
     \setbox0=\hbox{#2}%
     \ifdim\wd1<\wd0%
-      \strut\raise\SBChordRaise\copy1\kern-\wd1\copy0%
+      \strut\raise\SBChordRaise\copy1\kern-\wd1{#2}%
     \else%
-      \strut\copy0\kern-\wd0\strut\raise\SBChordRaise\copy1%
+      \strut{#2}\kern-\wd0\strut\raise\SBChordRaise\copy1%
     \fi%
   }{#2}%
  }%
 
-\newcommand{\ChordsBehind}[1]{
-   \ifthenelse{\boolean{PrintChordsBehind}}{
-     \if\blank{#1}{}\else{%\hskip 0.1cm 
-     \ChFontBh #1}\fi
-   }{
-   }
+\newcommand{\ChordsBehind}[1]{%
+\ifthenelse{\boolean{PrintChordsBehind}}{%
+\if\blank{#1}{}\else{%\hskip 0.1cm
+\ChFontBh #1}\fi%
+}{%
+}%
 }
-
 
 \newcommand{\AAndCAndA}[3]{%
    \vbox{%
@@ -90,7 +93,7 @@
        \if\blank{#1}{}\else{\textbf{Słowa:}\ #1 \\}\fi%
        \if\blank{#2}{}\else{\textbf{Muzyka:}\ #2 \\}\fi%
        \if\blank{#3}{}\else{\textbf{Wykonawca:}\ #3 \\}\fi%
-   \end{flushleft}%\\
+       \end{flushleft}%\\
    }%
 }
 
@@ -116,59 +119,34 @@
   \addcontentsline{toc}{section}{\hspace{-1.5em}#1}
   \STitle{\theSongTitle}
   \AAndCAndA{#2}{#3}{#4}
+  \parindent=0pt
   }{\vfill}
 
-\newcommand{\row}[5][M]{
+\newcommand{\row}[5][M]{%
 % #1:
 %     "F"  <=> (first line of verse (or chorus))
-%     "FS" <=> (first special)number and indent the verse or "Ch:" the chorus
 %     "L"  <=> (last line) don't try to nobreakline.
-%     "M"  <=> middleline
-%     "S"  <=> singleline   
+%     "I"  <=> instrumental line
+% - you can combine the lines
 % #2: "C"  <=> chorus
 %     "V"  <=> verse
-%     "I"  <=> instrumental 
+%     "O"  <=> not chorus and not numbered
 % #3: row_text
 % #4: bis_text
 % #5: chords
 %----------------------------------------------------------
-      \ifthenelse{\equal{#1}{L}}{\vspace{3 ex}}{}%
-      \ifthenelse{\equal{#1}{S}}{\vspace{3 ex}}{}%
-%      
-      \ifthenelse{\equal{#1}{FS}}%
-        { \ifthenelse{\equal{#2}{C}}%
-           {Ref.:}%
-           {\ifthenelse{\equal{#2}{V}}{%
-            \addtocounter{VerseCnt}{1}%
-            \theVerseCnt{}.%
-        }{}%
-           }%
-        }{}%
 %
-    \ifthenelse{\equal{#1}{S}}%
-        { \ifthenelse{\equal{#2}{C}}%
-           {Ref:}%
-           {\ifthenelse{\equal{#2}{V}}{%
-            \addtocounter{VerseCnt}{1}%
-            \theVerseCnt{}.%
-        }{}%
-           }%
-        }{} %
-        & %--------------------------------------------
-        \ifthenelse{\equal{#2}{C}}%
-           {\hskip 0.75 cm}%
-           {}%
-        #3 & %-----------------------------------------
-        \if\blank{#4}{}\else{% \hskip{1cm}
-          #4}\fi%
-        & %-----------------------------------------
-         \ChordsBehind{#5}%
-        %---------------------------------------
-        \ifthenelse{\equal{#1}{L}}%
-           {\\}%
-           {        \ifthenelse{\equal{#1}{S}}%
-           {\\}%
-           {\\*}}%
-
+    \IfSubStr{#1}{F}{%
+      \IfSubStr{#2}{C}{Ref:}{}%
+      \IfSubStr{#2}{V}{\addtocounter{VerseCnt}{1}\theVerseCnt{}.}{}%
+    }{}%
+    \IfSubStr{#1}{I}%
+        {&\multicolumn{2}{l}{\ChordsBehind{#5}} & }%
+        {&\ChordsBehind{#5} & %
+          \IfSubStr{#2}{C}{\hskip 1.5em}{} %
+          #3 & %
+        }%
+    \if\blank{#4}{}\else{#4}\fi%
+    \IfSubStr{#1}{L}{\IfSubStr{#1}{E}{\\}{\\\vtop{\vskip2ex minus 1ex}\\}}{\IfSubStr{#1}{P}{\\*}{\IfSubStr{#1}{F}{\\*}{\\}}} % optionally we could emit \\* on last-by-1 line to prevent 1-line tables.
 }{}
 

--- a/src/song_template.tex
+++ b/src/song_template.tex
@@ -1,9 +1,9 @@
 \begin{song}{\VAR{song.title}}{\VAR{song.text_author}}{\VAR{song.composer}}{\VAR{song.artist}}
-\begin{longtable}{l p{0.6\textwidth} l p{1in}}
-\endfirsthead  &\ldots  \endhead  &c.d.n. \ldots   \endfoot  \endlastfoot
+\begin{longtable}{l V{6em} p{0.6\textwidth} l@{}}
+&\ldots \endfoot  \endlastfoot
 \BLOCK{ for block in song.blocks }
     \BLOCK{ for row in block.rows }
-        \row[\VAR{row.row_type.value}]{\VAR{block.block_type.value}}{\BLOCK{ for chunk in row.chunks }
+        \row[\VAR{row.row_type}]{\VAR{block.block_type.value}}{\BLOCK{ for chunk in row.chunks }
             \BLOCK{ if not row.new_chords or not chunk.chord -}
                 \VAR{chunk.content}
             \BLOCK{- else -}
@@ -15,7 +15,7 @@
             \bisl{\VAR{row.bis}}
         \BLOCK{- endif }}{\BLOCK{ for chunk in row.chunks -}
             \BLOCK{ if chunk.chord }\VAR{chunk.chord} \BLOCK{ endif }
-        \BLOCK{- endfor }}
+        \BLOCK{- endfor }}%
     \BLOCK{ endfor }
 \BLOCK{ endfor }
 \end{longtable}


### PR DESCRIPTION
- Align begginings of the rows
- Allow breaking rows with chords
- Move chords to left side of text
- Avoid empty pages (due to breaking before empty line)
- Fix missspells
- Instrumental rows are spanning the whole column