### PR TITLE
Make generate PDFs more compact

### DIFF
--- a/INSTALL
+++ b/INSTALL
@@ -1,0 +1,12 @@
+installing on OSX:
+
+  brew install pkg-config icu4c python-build
+  export PATH="/usr/local/opt/icu4c/bin:$PATH"
+  pip3 install -r requirements.txt
+  Install mactex: https://www.tug.org/mactex/mactex-download.html
+
+installing on Linux:
+
+  sudo apt-get install python3-lxml
+  pip3 install -r requirements.txt
+  sudo apt-get install texlive texlive-latex-extra texlive-lang-polish

--- a/songs/Gloria.xml
+++ b/songs/Gloria.xml
@@ -50,7 +50,7 @@
       <row important_over="false"><ch a="D"/>Gloria gloria in excelsis eoli<ch a="G"/></row>
     </block>
     <block type="other" style="instr">
-      <row important_over="false">
+      <row important_over="false"  style="instr">
         <ch a="G"/>
         <ch a="e"/>
 

--- a/src/latex/song_template.tex
+++ b/src/latex/song_template.tex
@@ -2,7 +2,7 @@
 \begin{longtable}{l V{6em} p{0.6\textwidth} l@{}}
 &\ldots \endfoot  \endlastfoot
 \BLOCK{ for block in song.blocks }
-    \BLOCK{ for row in block.rows }
+    \BLOCK{ for row in block.effective_rows }
         \row[\VAR{row.row_type}]{\VAR{block.block_type.value}}{\BLOCK{ for chunk in row.chunks }
             \BLOCK{ if not row.new_chords or not chunk.chord -}
                 \VAR{chunk.content}

--- a/src/latex/songbook21wdh.sty
+++ b/src/latex/songbook21wdh.sty
@@ -88,23 +88,19 @@
 }
 
 \newcommand{\AAndCAndA}[3]{%
-   \vbox{%
-   \begin{flushleft}%
-   \small%
+ {%
+       \small%
        \if\blank{#1}{}\else{\textbf{Słowa:}\ #1 \\}\fi%
        \if\blank{#2}{}\else{\textbf{Muzyka:}\ #2 \\}\fi%
        \if\blank{#3}{}\else{\textbf{Wykonawca:}\ #3 \\}\fi%
-       \end{flushleft}%\\
-   }%
+  }%
 }
 
 \newcommand{\STitle}[1]{%
-   \vbox{%
-   \begin{center}%
-    {\LARGE{\ifthenelse{\boolean{PrintSongNum}}{\theSongCnt{}.\ }{}{\bf #1}}\\}%
-   \end{center}%
-  }%
-  }
+  {\LARGE\centering%
+    {\ifthenelse{\boolean{PrintSongNum}}{\theSongCnt{}.\ }{}{\bf #1\\}}}%
+}%
+
 
 \newenvironment{song}[4]{
   \clearpage 
@@ -165,6 +161,6 @@
       }%
       {\ChordsContext{#1#2}{}{#3}{#5}}%
     \if\blank{#4}{}\else{#4}\fi%
-    \IfSubStr{#1}{L}{\IfSubStr{#1}{E}{\\}{\\\vtop{\vskip2ex minus 1ex}\\}}{\IfSubStr{#1}{P}{\\*}{\IfSubStr{#1}{F}{\\*}{\\}}} % optionally we could emit \\* on last-by-1 line to prevent 1-line tables.
+    \IfSubStr{#1}{L}{\IfSubStr{#1}{E}{\\}{\\\vtop{\vskip1.5ex minus 1ex}\\}}{\IfSubStr{#1}{P}{\\*}{\IfSubStr{#1}{F}{\\*}{\\}}} % optionally we could emit \\* on last-by-1 line to prevent 1-line tables.
 }{}
 

--- a/src/latex/songbook21wdh.sty
+++ b/src/latex/songbook21wdh.sty
@@ -126,10 +126,23 @@
 
 \newcommand{\calb}[0]{\vline width 2pt {}}%
 
+% #1 - whether row is instrumental 'I' or/and it's chorus 'C'
+% #2 - intended row prefix (|| - for (not short chorus))
+% #3 - verse text
+% #4 - chords
+\newcommand{\ChordsContext}[4]{%
+  \IfSubStr{#1}{I}%
+    {&\multicolumn{2}{#2l}{\ChordsBehind{#4}} & }%
+    {&\multicolumn{1}{#2l}{\ChordsBehind{#4}} & \IfSubStr{#1}{C}{\hskip 2em}{} #3 & }%
+}%
+
+
 \newcommand{\row}[5][M]{%
 % #1:
 %     "F"  <=> (first line of verse (or chorus))
+%     "P"  <=> (last but 1 line - we don't page split after it)
 %     "L"  <=> (last line) don't try to nobreakline.
+%     'E'  <=> The very last verse of the song
 %     "I"  <=> instrumental line
 % - you can combine the lines
 % #2: "C"  <=> chorus
@@ -140,20 +153,17 @@
 % #5: chords
 %----------------------------------------------------------
 %
-%    \IfSubStr{#2}{C}{}{}
     \IfSubStr{#1}{F}{%
       \IfSubStr{#2}{C}{ Ref:}{}%
       \IfSubStr{#2}{V}{ \addtocounter{VerseCnt}{1}\theVerseCnt{}.}{}%
     }{}%
-    \IfSubStr{#2}{C}{%
-       \IfSubStr{#1}{I}%
-          {&\multicolumn{2}{||l}{\ChordsBehind{#5}} & }%
-          {&\multicolumn{1}{||l}{\ChordsBehind{#5}} & \hskip 2em #3 & }%
-    }{%
-       \IfSubStr{#1}{I}%
-          {&\multicolumn{2}{l}{\ChordsBehind{#5}} & }%
-          {&\multicolumn{1}{l}{\ChordsBehind{#5}} & #3 & }%
-    }%
+    \IfSubStr{#2}{C}%
+      {%
+      \IfSubStr{#1}{S}%
+        {\ChordsContext{#1#2}{}{#3}{#5}}%
+        {\ChordsContext{#1#2}{||}{#3}{#5}}%
+      }%
+      {\ChordsContext{#1#2}{}{#3}{#5}}%
     \if\blank{#4}{}\else{#4}\fi%
     \IfSubStr{#1}{L}{\IfSubStr{#1}{E}{\\}{\\\vtop{\vskip2ex minus 1ex}\\}}{\IfSubStr{#1}{P}{\\*}{\IfSubStr{#1}{F}{\\*}{\\}}} % optionally we could emit \\* on last-by-1 line to prevent 1-line tables.
 }{}


### PR DESCRIPTION
- Repeated choruses are referenced shortly
- There is no space after the last block (verse) that might cause creation of empty pages
- The spacing between blocks is smaller