### PR TITLE
Simplificing epub TOC generation to bring back upload to Kindle

### DIFF
--- a/src/epub/create_epub.py
+++ b/src/epub/create_epub.py
@@ -165,22 +165,29 @@ def create_toc_xhtml(list_of_songs_meta, target_dir, page_suffix):
     files.append(create_index_toc_xhtml(target_dir, page_suffix))
 
     toc_songs = extract_toc_songs(list_of_songs_meta)
-    for group in toc_songs:
-        if group:
-            parent_li = etree.SubElement(toc_ol, "li")
-            parent_a = etree.SubElement(parent_li, "span")
-            parent_a.text = group
-            parent_ol = etree.SubElement(parent_li, "ol")
-            toc_songs_to_xhtml(parent_ol, toc_songs[group])
-            files.append(create_group_toc_xhtml(group, toc_songs[group], target_dir, page_suffix))
-        else:
-            toc_songs_to_xhtml(toc_ol, toc_songs[group])
 
+    li = etree.SubElement(toc_ol, "li")
+    a = etree.SubElement(li, "a")
+    a.attrib['href'] = 'songs.xhtml'
+    a.text ="Piosenki"
 
     li = etree.SubElement(toc_ol, "li")
     a = etree.SubElement(li, "a")
     a.attrib['href'] = 'index.xhtml'
-    a.text ="Index"
+    a.text ="Indeks"
+
+    for group in toc_songs:
+        if group:
+            parent_li = etree.SubElement(toc_ol, "li")
+            parent_a = etree.SubElement(parent_li, "a", attrib={"href": "toc_" + group + ".xhtml"})
+            parent_a.text = group
+
+           # parent_ol = etree.SubElement(parent_li, "ol")
+           # toc_songs_to_xhtml(parent_ol, toc_songs[group])
+            files.append(create_group_toc_xhtml(group, toc_songs[group], target_dir, page_suffix))
+        else:
+            toc_songs_to_xhtml(toc_ol, toc_songs[group])
+
 
     et = etree.ElementTree(root)
     et.write(out_path, pretty_print=True, method='xml', encoding='utf-8', xml_declaration=True)
@@ -210,6 +217,7 @@ def create_template_epub(target_path):
     shutil.copyfile(path_tmp_css_template, os.path.join(path_css, "template.css"))
     shutil.copyfile(path_tmp_mimetype, os.path.join(path_epub, "mimetype"))
     shutil.copyfile(os.path.join(template_dir, "images", "cover.jpg"), os.path.join(path_images, "cover.jpg"))
+    shutil.copyfile(os.path.join(template_dir, "songs.xhtml"), os.path.join(path_oebps, "songs.xhtml"))
     cash.replace_in_file(os.path.join(template_dir, "cover.xhtml"), os.path.join(path_oebps, "cover.xhtml"),
                          lambda s: s.replace("{date}", actual_date()))
 

--- a/src/epub/templates/content.opf
+++ b/src/epub/templates/content.opf
@@ -15,6 +15,7 @@
         <item id="coverimage" href="images/cover.jpg" media-type="image/jpeg" properties="cover-image"/>
         <item id="cover" href="cover.xhtml" media-type="application/xhtml+xml"/>
         <item id="toc" href="toc.xhtml" media-type="application/xhtml+xml" properties="nav"/>
+        <item id="start" href="songs.xhtml" media-type="application/xhtml+xml"/>
         <!--item id="ncx" href="toc.ncx" media-type="application/x-dtbncx+xml"/-->
         <item id="template_css" href="CSS/template.css" media-type="text/css"/>
         <item id="song_css" href="CSS/song.css" media-type="text/css"/>
@@ -23,7 +24,13 @@
     <spine>
         <itemref idref="cover"/>
         <itemref idref="toc"/>
+        <itemref idref="start"/>
         <!--https://kdp.amazon.com/en_US/help/topic/G201605710-->
     </spine>
-
+    <guide>
+        <reference type="title-page" href="cover.xhtml" title="Strona tytułowa"/>
+        <reference type="toc" href="toc.xhtml" title="Spis treści"/>
+        <reference type="text" href="songs.xhtml" title="Piosenki"/>
+        <reference type="index" href="index.xhtml" title="Indeks"/>
+    </guide>
 </package>

--- a/src/epub/templates/songs.xhtml
+++ b/src/epub/templates/songs.xhtml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE html>
+<html xmlns="http://www.w3.org/1999/xhtml" xmlns:epub="http://www.idpf.org/2007/ops">
+<head>
+    <title>Index</title>
+    <link href="CSS/template.css" rel="stylesheet" type="text/css"/>
+</head>
+<body epub:type="frontmatter">
+   <h1>Piosenki</h1>
+</body>
+</html>

--- a/src/epub/templates/toc.xhtml
+++ b/src/epub/templates/toc.xhtml
@@ -16,6 +16,7 @@
     <ol>
         <li><a epub:type="cover" href="cover.xhtml">Okładka</a></li>
         <li><a epub:type="toc" href="#toc">Spis piosenek</a></li>
+        <li><a epub:type="bodymatter" href="songs.xhtml">Piosenki</a></li>
         <li><a epub:type="index" href="index.xhtml">Index</a></li>
     </ol>
 </nav>


### PR DESCRIPTION
- **Publish should trigger generate_all after name.**
- **Removed deep index of songs -> such that it works on Kindle (can be uploaded).**
