### PR TITLE
e z cyrylicy powinno być tłumaczone na łacińskie

### DIFF
--- a/editor/save.js
+++ b/editor/save.js
@@ -2,11 +2,14 @@ import {loadXMLDoc, nbsp} from './utils.js';
 
 function escapeText(unsafe) {
   return unsafe
-      .replace(/&/g, '&amp;')
-      .replace(/</g, '&lt;')
-      .replace(/>/g, '&gt;')
-      .replace(/"/g, "&quot;")
-      .replace(/'/g, "&#039;");
+      .replaceAll('\u{0435}',"e") // e in Cyrylic
+      .replaceAll(',,','\u{201E}')
+      .replaceAll('\'\'','\u{201D}')
+      .replaceAll(/&/g, '&amp;')
+      .replaceAll(/</g, '&lt;')
+      .replaceAll(/>/g, '&gt;')
+      .replaceAll(/"/g, "&quot;")
+      .replaceAll(/'/g, "&#039;");
 }
 
 function escapeAttrib(unsafe) {


### PR DESCRIPTION
Bez tego, takie błędy się zdarzają:

```
[Loading MPS to PDF converter (version 2006.09.02).]
) (/usr/share/texlive/texmf-dist/tex/latex/epstopdf-pkg/epstopdf-base.sty
(/usr/share/texlive/texmf-dist/tex/latex/latexconfig/epstopdf-sys.cfg))

LaTeX Font Warning: Font shape `T1/phv/sbc/n' undefined
(Font)              using `T1/phv/m/n' instead on input line 43.

! LaTeX Error: Unicode character е (U+0435)
               not set up for use with LaTeX.

See the LaTeX manual or LaTeX Companion for explanation.
Type  H <return>  for immediate help.
 ...

l.64 ...iatr wiejе ze wszystkich stron}{}{fis E }
                                                  %
?
! Emergency stop.
 ...

l.64 ...iatr wiejе ze wszystkich stron}{}{fis E }

```
